### PR TITLE
Don't display updated date when a post has not been updated

### DIFF
--- a/PTBlog/Views/Posts/Listing.cshtml
+++ b/PTBlog/Views/Posts/Listing.cshtml
@@ -13,7 +13,11 @@
 
 	<details>
 		<p>Created On: @Html.DisplayFor(p => p.CreatedDate)</p>
-		<p>Updated On: @Html.DisplayFor(p => p.UpdatedDate)</p>
+		@if (Model.UpdatedDate is not null)
+		{
+			<p>Updated On: @Html.DisplayFor(p => p.UpdatedDate)</p>
+		}
+
 		<h2>Actions:</h2>
 		@await Html.PartialAsync("~/Views/Posts/_PostActionButtonsPartial.cshtml")
 	</details>


### PR DESCRIPTION
Before if a post wasn't updated in the details section if a post has not been updated it would display "Updated Date:".