### PR TITLE
Fix editing being broken due to a wrong route

### DIFF
--- a/PTBlog/Controllers/PostsController.cs
+++ b/PTBlog/Controllers/PostsController.cs
@@ -75,7 +75,7 @@ public sealed class PostsController : Controller
 		return View(new PostDTO{ Title = post.Title, Content = post.Content });
     }
 
-    [HttpPost("{action}/{id}")]
+    [HttpPost("Edit/{id}")]
     [Authorize]
     public async Task<IActionResult> EditConfirmed(int id, [Bind("Title,Content")]PostDTO postDto)
     {


### PR DESCRIPTION
When we changed the name of Edit to EditConfirmed, we forgot to change the action route to stay as edit.