### PR TITLE
Add a GetHashCode override for PostModel

### DIFF
--- a/PTBlog/Models/PostModel.cs
+++ b/PTBlog/Models/PostModel.cs
@@ -34,4 +34,9 @@ public sealed class PostModel
 
 		return false;
 	}
+
+	public override int GetHashCode()
+	{
+		return HashCode.Combine(Title, Content, AuthorId);
+	}
 }


### PR DESCRIPTION
If you override equals it's good practice to override gethashcode so that equal objects also have the same hash code.