### PR TITLE
Return null if no posts exists when calling GetLatestPostAsync

### DIFF
--- a/PTBlog/Data/Repositories/PostsRepository.cs
+++ b/PTBlog/Data/Repositories/PostsRepository.cs
@@ -17,7 +17,7 @@ public sealed class PostsRepository : IPostsRepository
 
 	public async Task<PostModel?> GetLatestPostAsync()
 	{
-		return await GetPostsOrderedByCreationDate().FirstAsync();
+		return await GetPostsOrderedByCreationDate().FirstOrDefaultAsync();
 	}
 
 	public async Task<List<PostModel>> GetPostsByTitleAsync(string wantedTitle)


### PR DESCRIPTION
This prevents an exception when trying to display the latest post on the index page when no posts exist.